### PR TITLE
Some improvements

### DIFF
--- a/src/ast/luaparse.d.ts
+++ b/src/ast/luaparse.d.ts
@@ -162,7 +162,7 @@ declare module "luaparse" {
 
     export interface TableConstructorExpression extends Node {
         type: "TableConstructorExpression";
-        fields: Array<TableValue | TableKeyString>;
+        fields: Array<TableValue | TableKey | TableKeyString>;
     }
 
     export interface UnaryExpression extends Node {
@@ -190,9 +190,15 @@ declare module "luaparse" {
         value: Expression;
     }
 
+    export interface TableKey extends Node {
+        type: "TableKey";
+        key: Expression;
+        value: Expression;
+    }
+
     export interface TableKeyString extends Node {
         type: "TableKeyString";
-        key: Expression;
+        key: Identifier;
         value: Expression;
     }
 

--- a/src/transpile.test.ts
+++ b/src/transpile.test.ts
@@ -31,4 +31,14 @@ describe("Check transpiler output", () => {
             expect(receivedTsCode).toStrictEqual(expectedTsCode);
         });
     });
+    describe("Table Constructors", () => {
+        test.each([
+            ["a = { b, c }", "a = [b, c];", "TableValue x2"],
+            ["a = { b = 1, c = 2 }", "a = { b: 1, c: 2 };", "TableKeyString x2"],
+            ["a = { [b] = 1, [c] = 2 }", "a = { [b]: 1, [c]: 2 };", "TableKey x2"],
+        ])("%p transforms into %p. (%p)", (luaCode, expectedTsCode) => {
+            const { tsCode: receivedTsCode } = transformLuaToTypeScript(luaCode);
+            expect(receivedTsCode).toStrictEqual(expectedTsCode);
+        });
+    });
 });

--- a/src/transpile.test.ts
+++ b/src/transpile.test.ts
@@ -1,0 +1,34 @@
+import { transformLuaToTypeScript } from "./transpile";
+
+describe("Check transpiler output", () => {
+    describe("Local Statements", () => {
+        test.each([
+            ["local a", "let a;", "Identifier"],
+            ["local a = 1", "let a = 1;", "Identifier -> NumericLiteral"],
+            ["local a = 'string'", 'let a = "string";', "Identifier -> StringLiteral"],
+            ["local a, b = 1, 2", "let [a, b] = [1, 2];", "Identifier x2 -> NumericLiteral x2"],
+            ["local a, b = xy()", "let [a, b] = xy();", "Identifier x2 -> CallExpression"],
+        ])("%p transforms into %p. (%p)", (luaCode, expectedTsCode) => {
+            const { tsCode: receivedTsCode } = transformLuaToTypeScript(luaCode);
+            expect(receivedTsCode).toStrictEqual(expectedTsCode);
+        });
+    });
+    describe("Assignment Statements", () => {
+        test.each([
+            ["a = 1", "a = 1;", "Identifier -> NumericLiteral"],
+            ["a.b = 1", "a.b = 1;", "MemberExpression -> NumericLiteral"],
+            ["table[index] = 1", "table[index] = 1;", "IndexExpression -> NumericLiteral"],
+            ["a, b = xy()", "[a, b] = xy();", "Identifier x2 -> CallExpression"],
+            ["a.b, a.c = xy()", "[a.b, a.c] = xy();", "MemberExpression x2 -> CallExpression"],
+            [
+                "table[index], table[index] = 1, 2",
+                "[table[index], table[index]] = [1, 2];",
+                "IndexExpression x2 -> NumericLiteral x2",
+            ],
+            ["a, b = xy()", "[a, b] = xy();", "Identifier x2 -> CallExpression"],
+        ])("%p transforms into %p. (%p)", (luaCode, expectedTsCode) => {
+            const { tsCode: receivedTsCode } = transformLuaToTypeScript(luaCode);
+            expect(receivedTsCode).toStrictEqual(expectedTsCode);
+        });
+    });
+});


### PR DESCRIPTION
## Transform `a, b = c` into `[a, b] = c` (instead of `[a, b] = [c]`)

For example, this:

```lua
local contents, size = love.filesystem.read(fname)
```

now becomes this:

```ts
let [contents, size] = love.filesystem.read(fname);
```

## Transform `{ [a] = b }` into `{ [a]: b }` (instead of `{ a: b }`)

```lua
local a, b = "foo", "bar"
local tab = { [a] = b }
for k, v in pairs(tab) do
  print(k .. ": " .. v)
end
```

Output:

```
foo: bar
```

Implementation note: [`TableKeyString.key` is always an `Identifier`](https://github.com/fstirlitz/luaparse/blob/0f525b152516bc8afa34564de2423b039aa83bc1/luaparse.js#L2320-L2323)